### PR TITLE
correct cesaTest.js and finish cesa.js

### DIFF
--- a/lib/cesa.js
+++ b/lib/cesa.js
@@ -1,13 +1,34 @@
-var M = module.exports = {}
-
-M.encoding = function (clear) {
-    // TODO : 寫一個函數將字串中的所有字母位移n個單位,並輸出到cesa.txt
-    throw new Error('cesa.encoding() not implemented!')
-    return secret
+var M = module.exports = {
+  step: 5
 }
 
-M.decoding = function () {
-    // TODO : 讀取cesa.txt中的secret code 跟stars,再解碼
-    throw new Error('cesa.decoding() not implemented!')
-    return clear
+// step = 5 , a+5 = f
+// 明文 : My name is Joe
+// 密文: Rd sfrj nx Otj    
+// 修正：(原本寫成 Rd sfrk nx otk) 是否算錯了，k 應該是 j，而且 O 應該是大寫。
+M.encoding = function (clear) {
+  // TODO : 寫一個函數將字串中的所有字母位移n個單位,並輸出到cesa.txt
+  let secret = []
+  for (let i = 0; i < clear.length; i++) {
+    let base = null
+    let c = clear[i]
+    if (c >= 'a' && c <= 'z') base = 'a'.charCodeAt(0)
+    if (c >= 'A' && c <= 'Z') base = 'A'.charCodeAt(0)
+    if (base == null) {
+      secret.push(c)
+    } else {
+      let code = (clear.charCodeAt(i) - base + M.step + 26) % 26 + base
+      let c1 = String.fromCharCode(code)
+      secret.push(c1)
+    }
+  }
+  return secret.join('')
+}
+
+M.decoding = function (secret) {
+  // TODO : 讀取cesa.txt中的secret code 跟stars,再解碼
+  M.step *= -1
+  let clear = M.encoding(secret)
+  M.step *= -1
+  return clear
 }

--- a/lib/cesa.js
+++ b/lib/cesa.js
@@ -2,33 +2,35 @@ var M = module.exports = {
   step: 5
 }
 
-// step = 5 , a+5 = f
-// 明文 : My name is Joe
-// 密文: Rd sfrj nx Otj    
-// 修正：(原本寫成 Rd sfrk nx otk) 是否算錯了，k 應該是 j，而且 O 應該是大寫。
-M.encoding = function (clear) {
+M.translate = function (step, source) {
   // TODO : 寫一個函數將字串中的所有字母位移n個單位,並輸出到cesa.txt
-  let secret = []
-  for (let i = 0; i < clear.length; i++) {
+  let target = []
+  for (let i = 0; i < source.length; i++) {
     let base = null
-    let c = clear[i]
+    let c = source[i]
     if (c >= 'a' && c <= 'z') base = 'a'.charCodeAt(0)
     if (c >= 'A' && c <= 'Z') base = 'A'.charCodeAt(0)
     if (base == null) {
-      secret.push(c)
+      target.push(c)
     } else {
-      let code = (clear.charCodeAt(i) - base + M.step + 26) % 26 + base
+      let code = (source.charCodeAt(i) - base + step + 26) % 26 + base
       let c1 = String.fromCharCode(code)
-      secret.push(c1)
+      target.push(c1)
     }
   }
-  return secret.join('')
+  return target.join('')
+}
+
+// step = 5 , a+5 = f
+// 明文 : My name is Joe
+// 密文: Rd sfrj nx Otj
+// 修正：(原本寫成 Rd sfrk nx otk) 是否算錯了，k 應該是 j，而且 O 應該是大寫。
+M.encoding = function (clear) {
+  // TODO : 寫一個函數將字串中的所有字母位移n個單位,並輸出到cesa.txt
+  return M.translate(M.step, clear)
 }
 
 M.decoding = function (secret) {
   // TODO : 讀取cesa.txt中的secret code 跟stars,再解碼
-  M.step *= -1
-  let clear = M.encoding(secret)
-  M.step *= -1
-  return clear
+  return M.translate(-M.step, secret)
 }

--- a/test/cesaTest.js
+++ b/test/cesaTest.js
@@ -6,7 +6,7 @@ describe('cesa', function () {
     
     describe('凱薩編碼測試', function () {
         it('cesa.encoding(My name is Joe)', function () {
-            expect(cesa.encoding('My name is Joe')).to.equal('Rd sfrk nx otk')
+            expect(cesa.encoding('My name is Joe')).to.equal('Rd sfrj nx Otj')
         })  
     })
 })
@@ -15,8 +15,8 @@ describe('cesa', function () {
     var cesa = require('../lib/cesa')
    
     describe('凱薩編碼測試', function () {
-        it('cesa.decoding(Rd sfrk nx otk', function () {
-            expect(cesa.decoding('Rd sfrk nx otk')).to.equal('My name is Joe')
+        it('cesa.decoding(Rd sfrj nx Otj)', function () {
+            expect(cesa.decoding('Rd sfrj nx Otj')).to.equal('My name is Joe')
          })     
     })
 })


### PR DESCRIPTION
原本 https://github.com/joe5343281/Caesar-cipher/blob/master/test/cesaTest.js 裡面的 test case 範例似乎有錯，說明如下：

            expect(cesa.encoding('My name is Joe')).to.equal('Rd sfrk nx otk')

是否應該是 

            expect(cesa.encoding('My name is Joe')).to.equal('Rd sfrj nx Otj')

其中的 k 應該改成 j，o 應該改為大寫的 O。

同樣的，解密的測試範例應該是

            expect(cesa.decoding('Rd sfrj nx Otj')).to.equal('My name is Joe')

是這樣嗎？還是我理解有誤？

若是這樣，那麼 encoding 與 decoding 的實作就完成了，請合併到 master !
